### PR TITLE
Bump fmt to 11.2.0 to avoid problems in apple-clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ CMakeUserPresets.json
 *conanrun*.sh
 *.bat
 .vscode
+.venv

--- a/lesson1/conanfile.txt
+++ b/lesson1/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-fmt/11.0.2
+fmt/11.2.0
 
 [generators]
 CMakeDeps

--- a/lesson2/conanfile.txt
+++ b/lesson2/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-fmt/11.0.2
+fmt/11.2.0
 
 [generators]
 CMakeDeps

--- a/lesson3/conanfile.py
+++ b/lesson3/conanfile.py
@@ -6,7 +6,7 @@ class FormatterRecipe(ConanFile):
     generators = "CMakeToolchain", "CMakeDeps"
 
     def requirements(self):
-        self.requires("fmt/11.0.2")
+        self.requires("fmt/11.2.0")
     
     def layout(self):
         cmake_layout(self)

--- a/lesson3/conanfile_complete.py
+++ b/lesson3/conanfile_complete.py
@@ -25,7 +25,7 @@ class FormatterRecipe(ConanFile):
 
     def requirements(self):
         if not self.options.with_std_format:
-            self.requires("fmt/11.0.2")
+            self.requires("fmt/11.2.0")
 
     def layout(self):
         cmake_layout(self)

--- a/lesson4/conanfile.py
+++ b/lesson4/conanfile.py
@@ -6,7 +6,7 @@ class FormatterRecipe(ConanFile):
     generators = "CMakeToolchain", "CMakeDeps"
 
     def requirements(self):
-        self.requires("fmt/11.0.2")
+        self.requires("fmt/11.2.0")
 
     def build_requirements(self):
         self.tool_requires("cmake/3.31.5")

--- a/lesson5/conanfile.py
+++ b/lesson5/conanfile.py
@@ -6,7 +6,7 @@ class FormatterRecipe(ConanFile):
     generators = "CMakeToolchain", "CMakeDeps"
 
     def requirements(self):
-        self.requires("fmt/11.0.2")
+        self.requires("fmt/11.2.0")
 
     def build_requirements(self):
         self.tool_requires("cmake/3.31.5")

--- a/lesson7/conanfile.py
+++ b/lesson7/conanfile.py
@@ -6,7 +6,7 @@ class FormatterRecipe(ConanFile):
     generators = "CMakeToolchain", "CMakeDeps"
 
     def requirements(self):
-        self.requires("fmt/11.0.2")
+        self.requires("fmt/11.2.0")
 
     def build_requirements(self):
         self.tool_requires("cmake/3.31.5")

--- a/lesson9/conanfile.py
+++ b/lesson9/conanfile.py
@@ -41,7 +41,7 @@ class helloRecipe(ConanFile):
 
     def requirements(self):
         if self.options.with_fmt:
-            self.requires("fmt/11.0.2")
+            self.requires("fmt/11.2.0")
 
     def generate(self):
         deps = CMakeDeps(self)


### PR DESCRIPTION
There were some errors in clang, fixed here: https://github.com/fmtlib/fmt/commit/6e462b89aa22fd5f737ed162d0150e145ccb1914